### PR TITLE
Ignore MapSchedule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 storage/*
 logs
+cdn/gameassets/MapSchedule_v2.xml


### PR DESCRIPTION
Ignore Mapschedule file on git pull server update because it would overwrite the updated MapSchedule file which got updated with the map schedule update script.